### PR TITLE
chore: add pnpm lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mail_auto",
+  "version": "1.0.0",
+  "private": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
## Summary
- add a minimal package.json so pnpm can manage the workspace
- generate pnpm-lock.yaml with the current (empty) dependency set

## Testing
- pnpm install --lockfile-only

------
https://chatgpt.com/codex/tasks/task_b_68dc5cc9a8888326821ec8d629ab8d17